### PR TITLE
primes: Use gcd method in the math module

### DIFF
--- a/basehash/primes.py
+++ b/basehash/primes.py
@@ -35,7 +35,11 @@ def modinv(n, m):
 
 
 def gcd(*n):
-    from fractions import gcd
+    try:
+        from math import gcd
+    except ImportError:
+        # Python 3.4 and earlier
+        from fractions import gcd
 
     return abs(reduce(gcd, n))
 


### PR DESCRIPTION
The fractions.gcd method is deprecated since Python 3.5 and removed
since Python 3.9. Use math.gcd instead, available since Python 3.5, and
fallback to fractions.gcd only if math.gcd is not available.

This makes basehash work with Python 3.9.